### PR TITLE
bump stdlib to include < 6. let rspec-puppet just install. fix the puppetdb_rundeck_spec test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,7 @@ group :development, :test do
 
   gem 'rake',                                                                    :require => false
   gem 'puppet-lint',                                                             :require => false
-  gem 'rspec-puppet',
-    :git => 'https://github.com/rodjek/rspec-puppet.git',
-    :ref => '',
-    :require => false
+  gem 'rspec-puppet',                                                            :require => false
   gem 'puppet-syntax',                                                           :require => false
   gem 'puppetlabs_spec_helper',                                                  :require => false
   gem 'rspec',                                                                   :require => false

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0 <5.0.0"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     }
   ]
 }

--- a/spec/classes/puppetdb_rundeck_spec.rb
+++ b/spec/classes/puppetdb_rundeck_spec.rb
@@ -12,7 +12,7 @@ describe 'puppetdb_rundeck' do
         it { should compile.with_all_deps }
 
         it { should contain_class('puppetdb_rundeck::params') }
-        it { should contain_class('puppetdb_rundeck::install').that_comes_before('puppetdb_rundeck::service') }
+        it { should contain_class('puppetdb_rundeck::install').that_comes_before('Class[puppetdb_rundeck::service]') }
         it { should contain_class('puppetdb_rundeck::service') }
 
         it { should contain_service('puppetdb_rundeck') }


### PR DESCRIPTION
## What
* bumps up the stdlib version range
* have rspec-puppet install be generic
* fix up one of the spec tests

## Impact
none other than goodness. no changes will be made.